### PR TITLE
Add fixed jar name for Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+# Use Gradle image to build the application
+FROM gradle:8-jdk21 AS build
+WORKDIR /app
+COPY . .
+RUN gradle bootJar --no-daemon
+
+# Use JDK runtime for running the built jar
+FROM openjdk:21-jdk-slim
+WORKDIR /app
+COPY --from=build /app/build/libs/devmark.jar devmark.jar
+CMD ["java", "-jar", "devmark.jar"]
+

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,3 +40,9 @@ kotlin {
 tasks.withType<Test> {
     useJUnitPlatform()
 }
+
+tasks {
+    bootJar {
+        archiveFileName.set("devmark.jar")
+    }
+}


### PR DESCRIPTION
## Summary
- simplify Gradle config using `tasks.withType<Test>` and keep BootJar inside `tasks` block
- keep jar name `devmark.jar` for Docker image

## Testing
- `./gradlew test --no-daemon`
- `./gradlew bootJar --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_686d97759f18832e8555502c4ba49f05